### PR TITLE
Migration Flutter 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 2.3.0
+## 2.4.0 - August 19 2022
+- Flutter 3.0 Minimum SDK
 
+## 2.3.0
 - [iOS] Added support for iOS 10
 
 ## 2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,9 @@
 name: flutter_file_dialog
 description: Dialogs for picking and saving files in Android and in iOS.
-version: 2.3.0
+version: 2.3.1
 homepage: https://github.com/kineapps/flutter_file_dialog
 repository: https://github.com/kineapps/flutter_file_dialog
+publish_to: http://pub.dev.internal
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,8 @@ repository: https://github.com/kineapps/flutter_file_dialog
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
-
+  flutter: ">=1.12.0"
+  
 dependencies:
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,11 @@
 name: flutter_file_dialog
 description: Dialogs for picking and saving files in Android and in iOS.
-version: 2.3.1
+version: 2.4.0
 homepage: https://github.com/kineapps/flutter_file_dialog
 repository: https://github.com/kineapps/flutter_file_dialog
-publish_to: http://pub.dev.internal
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.12.0"
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
To migration support Flutter 3, I changed several code:
- SDK Minimum Version to 2.17.0 as referenced in the [official site](https://docs.flutter.dev/development/tools/sdk/releases)
- Update Version to 2.4.0 to mark any changes for this package
- Update Changelog to announce the changed