### PR TITLE
Fix AGP 8.0 compile error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,15 @@ android {
     namespace 'com.kineapps.flutter_file_dialog'
     compileSdkVersion 33
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+    
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
@kinex 
This PR fixes the Kotlin version mismatch when building with AGP 8.0.
Like most other packages, the versions have been set to Kotlin and Java 1.8.