### PR TITLE
Fix fatal "Reply already submitted" crash in FileDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.2
+
+- [Android] Fix fatal "Reply already submitted" crash (#58): complete every dialog result exactly once, reply with an "already_active" error when a dialog is already open instead of leaving the call unanswered, stop stale activity-result listeners from processing dialog results after plugin re-attachment, and stop a slow post-dialog file copy from blocking subsequent dialogs
+
 ## 3.3.1
 
 - [Android] Fix "Could not find method kotlin()" build failure on AGP 9 when built-in Kotlin is disabled (the Flutter template default) — only configure the kotlin {} DSL when the Kotlin Gradle Plugin is applied, and apply KGP when built-in Kotlin is off

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,6 +58,9 @@ android {
     lint {
         disable 'InvalidPackage'
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 // The kotlin {} DSL is only registered when the Kotlin Gradle Plugin is applied;
@@ -74,4 +77,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     implementation 'androidx.documentfile:documentfile:1.0.1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.14.2'
 }

--- a/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
+++ b/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
@@ -25,10 +25,11 @@ import java.util.concurrent.atomic.AtomicInteger
 private const val LOG_TAG = "FileDialog"
 
 // request codes are allocated per dialog launch (see nextRequestCode) so a
-// stale or re-delivered activity result from an earlier launch can never be
-// matched to a newer launch's pending result
+// stale or re-delivered activity result from an earlier launch cannot be
+// matched to a newer launch's pending result (codes wrap only after
+// REQUEST_CODE_RANGE launches, and must stay below the 0xFFFF Android limit)
 private const val REQUEST_CODE_BASE = 19110
-private const val REQUEST_CODE_RANGE = 300
+private const val REQUEST_CODE_RANGE = 40000
 
 // https://developer.android.com/guide/topics/providers/document-provider
 // https://developer.android.com/reference/android/content/Intent.html#ACTION_CREATE_DOCUMENT
@@ -468,9 +469,20 @@ class FileDialog(
      * pending, so the Dart future resolves instead of hanging forever.
      */
     internal fun cancelPendingResult() {
-        val result = takePendingResult() ?: return
+        val dialog: PendingDialog?
+        synchronized(resultLock) {
+            dialog = pendingDialog
+            pendingDialog = null
+        }
+        if (dialog == null) {
+            return
+        }
         Log.w(LOG_TAG, "Cancelling pending result")
-        result.success(null)
+        if (dialog.operation == DialogOperation.SAVE_FILE && isSourceFileTemp) {
+            Log.d(LOG_TAG, "Deleting source file: ${sourceFile?.path}")
+            sourceFile?.delete()
+        }
+        dialog.result.success(null)
     }
 
     private fun finishWithError(errorCode: String, errorMessage: String?, errorDetails: String?) {

--- a/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
+++ b/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
@@ -165,6 +165,14 @@ class FileDialog(
             return
         }
 
+        if (sourceFilePath == null && (fileName == null || data == null)) {
+            result.error(
+                "invalid_arguments",
+                "Missing 'fileName' or 'data'",
+                null)
+            return
+        }
+
         val requestCode = setPendingDialog(DialogOperation.SAVE_FILE, result)
         if (requestCode == null) {
             finishWithAlreadyActiveError(result)
@@ -183,10 +191,17 @@ class FileDialog(
                 return
             }
         } else {
-            // write data to a temporary file
+            // write data to a temporary file; on failure release the
+            // pending-dialog slot so later calls do not get already_active
             isSourceFileTemp = true
-            sourceFile = File.createTempFile(fileName!!, "")
-            sourceFile!!.writeBytes(data!!)
+            try {
+                sourceFile = File.createTempFile(fileName!!, "")
+                sourceFile!!.writeBytes(data!!)
+            } catch (e: Exception) {
+                Log.e(LOG_TAG, "saveFile - creating temporary file failed", e)
+                finishWithError("save_file_failed", e.localizedMessage, e.toString())
+                return
+            }
         }
 
         val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)

--- a/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
+++ b/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
@@ -19,12 +19,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 private const val LOG_TAG = "FileDialog"
 
-private const val REQUEST_CODE_PICK_DIR = 19110
-private const val REQUEST_CODE_PICK_FILE = 19111
-private const val REQUEST_CODE_SAVE_FILE = 19112
+// request codes are allocated per dialog launch (see nextRequestCode) so a
+// stale or re-delivered activity result from an earlier launch can never be
+// matched to a newer launch's pending result
+private const val REQUEST_CODE_BASE = 19110
+private const val REQUEST_CODE_RANGE = 300
 
 // https://developer.android.com/guide/topics/providers/document-provider
 // https://developer.android.com/reference/android/content/Intent.html#ACTION_CREATE_DOCUMENT
@@ -33,7 +37,26 @@ class FileDialog(
         private var activity: Activity?
 ) : PluginRegistry.ActivityResultListener {
 
-    private var pendingResult: MethodChannel.Result? = null
+    companion object {
+        private val requestCodeCounter = AtomicInteger(0)
+
+        private fun nextRequestCode(): Int =
+                REQUEST_CODE_BASE + Math.floorMod(requestCodeCounter.getAndIncrement(), REQUEST_CODE_RANGE)
+    }
+
+    private enum class DialogOperation { PICK_DIRECTORY, PICK_FILE, SAVE_FILE }
+
+    private class PendingDialog(
+            val operation: DialogOperation,
+            val result: MethodChannel.Result,
+            val requestCode: Int
+    )
+
+    private var pendingDialog: PendingDialog? = null
+
+    // request code of the currently pending dialog launch, -1 if none
+    internal val pendingRequestCode: Int
+        get() = synchronized(resultLock) { pendingDialog?.requestCode ?: -1 }
     private var fileExtensionsFilter: Array<String>? = null
     private var copyPickedFileToCacheDir: Boolean = true
 
@@ -50,7 +73,7 @@ class FileDialog(
 
     fun pickDirectory(result: MethodChannel.Result) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            finishWithError(
+            result.error(
                     "minimum_target",
                     "pickDirectory() available only on Android 21 and above",
                     ""
@@ -59,7 +82,7 @@ class FileDialog(
         }
 
         if (activity == null) {
-            finishWithError(
+            result.error(
                 "internal_error",
                 "No activity is available",
                 "")
@@ -68,13 +91,14 @@ class FileDialog(
 
         Log.d(LOG_TAG, "pickDirectory - IN")
 
-        if (!setPendingResult(result)) {
+        val requestCode = setPendingDialog(DialogOperation.PICK_DIRECTORY, result)
+        if (requestCode == null) {
             finishWithAlreadyActiveError(result)
             return
         }
 
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-        activity?.startActivityForResult(intent, REQUEST_CODE_PICK_DIR)
+        activity?.startActivityForResult(intent, requestCode)
 
         Log.d(LOG_TAG, "pickDirectory - OUT")
     }
@@ -92,14 +116,15 @@ class FileDialog(
         Log.d(LOG_TAG, "pickFile - IN, fileExtensionsFilter=$fileExtensionsFilter, mimeTypesFilter=$mimeTypesFilter, localOnly=$localOnly, copyFileToCacheDir=$copyFileToCacheDir")
 
         if (activity == null) {
-            finishWithError(
+            result.error(
                 "internal_error",
                 "No activity is available",
                 "")
             return
         }
 
-        if (!setPendingResult(result)) {
+        val requestCode = setPendingDialog(DialogOperation.PICK_FILE, result)
+        if (requestCode == null) {
             finishWithAlreadyActiveError(result)
             return
         }
@@ -115,7 +140,7 @@ class FileDialog(
             applyMimeTypesFilterToIntent(mimeTypesFilter, this)
         }
 
-        activity?.startActivityForResult(intent, REQUEST_CODE_PICK_FILE)
+        activity?.startActivityForResult(intent, requestCode)
 
         Log.d(LOG_TAG, "pickFile - OUT")
     }
@@ -131,7 +156,16 @@ class FileDialog(
                 "data=${data?.size} bytes, fileName=$fileName, " +
                 "mimeTypesFilter=$mimeTypesFilter, localOnly=$localOnly")
 
-        if (!setPendingResult(result)) {
+        if (activity == null) {
+            result.error(
+                "internal_error",
+                "No activity is available",
+                "")
+            return
+        }
+
+        val requestCode = setPendingDialog(DialogOperation.SAVE_FILE, result)
+        if (requestCode == null) {
             finishWithAlreadyActiveError(result)
             return
         }
@@ -162,15 +196,7 @@ class FileDialog(
         }
         applyMimeTypesFilterToIntent(mimeTypesFilter, intent)
 
-        if (activity == null) {
-            finishWithError(
-                "internal_error",
-                "No activity is available",
-                "")
-            return
-        }
-
-        activity?.startActivityForResult(intent, REQUEST_CODE_SAVE_FILE)
+        activity?.startActivityForResult(intent, requestCode)
 
         Log.d(LOG_TAG, "saveFile - OUT")
     }
@@ -189,27 +215,41 @@ class FileDialog(
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        if (activity == null) {
-            finishWithError(
-                "internal_error",
-                "No activity is available",
-                "")
-            return true
+        // take ownership of the pending result here so a slow post-dialog step
+        // can never block or complete a later dialog's result; consume it only
+        // when the request code matches the pending launch, so a re-delivered
+        // result from an earlier launch can never complete a newer dialog's
+        val pending: PendingDialog
+        synchronized(resultLock) {
+            val current = pendingDialog
+            if (current == null || current.requestCode != requestCode) {
+                return false
+            }
+            pendingDialog = null
+            pending = current
         }
-
-        when (requestCode) {
-            REQUEST_CODE_PICK_DIR -> {
+        val result = pending.result
+        when (pending.operation) {
+            DialogOperation.PICK_DIRECTORY -> {
                 if (resultCode == Activity.RESULT_OK && data?.data != null) {
                     val sourceFileUri = data.data
                     Log.d(LOG_TAG, "Picked directory: $sourceFileUri")
-                    finishSuccessfully(sourceFileUri!!.toString())
+                    result.success(sourceFileUri!!.toString())
                 } else {
                     Log.d(LOG_TAG, "Cancelled")
-                    finishSuccessfully(null)
+                    result.success(null)
                 }
                 return true
             }
-            REQUEST_CODE_PICK_FILE -> {
+            DialogOperation.PICK_FILE -> {
+                val activity = this.activity
+                if (activity == null) {
+                    result.error(
+                        "internal_error",
+                        "No activity is available",
+                        "")
+                    return true
+                }
                 if (resultCode == Activity.RESULT_OK && data?.data != null) {
                     val sourceFileUri = data.data
                     Log.d(LOG_TAG, "Picked file: $sourceFileUri")
@@ -217,60 +257,70 @@ class FileDialog(
                     if (destinationFileName != null && validateFileExtension(destinationFileName)) {
                         if (copyPickedFileToCacheDir) {
                             copyFileToCacheDirOnBackground(
-                                    context = activity!!,
+                                    context = activity,
                                     sourceFileUri = sourceFileUri!!,
-                                    destinationFileName = destinationFileName)
+                                    destinationFileName = destinationFileName,
+                                    result = result)
                         } else {
-                            finishSuccessfully(sourceFileUri!!.toString())
+                            result.success(sourceFileUri!!.toString())
                         }
                     } else {
-                        finishWithError(
+                        result.error(
                                 "invalid_file_extension",
                                 "Invalid file type was picked",
                                 getFileExtension(destinationFileName))
                     }
                 } else {
                     Log.d(LOG_TAG, "Cancelled")
-                    finishSuccessfully(null)
+                    result.success(null)
                 }
                 return true
             }
-            REQUEST_CODE_SAVE_FILE -> {
+            DialogOperation.SAVE_FILE -> {
+                if (activity == null) {
+                    if (isSourceFileTemp) {
+                        Log.d(LOG_TAG, "Deleting source file: ${sourceFile?.path}")
+                        sourceFile?.delete()
+                    }
+                    result.error(
+                        "internal_error",
+                        "No activity is available",
+                        "")
+                    return true
+                }
                 if (resultCode == Activity.RESULT_OK && data?.data != null) {
                     val destinationFileUri = data.data
-                    saveFileOnBackground(this.sourceFile!!, destinationFileUri!!)
+                    saveFileOnBackground(this.sourceFile!!, destinationFileUri!!, isSourceFileTemp, result)
                 } else {
                     Log.d(LOG_TAG, "Cancelled")
                     if (isSourceFileTemp) {
                         Log.d(LOG_TAG, "Deleting source file: ${sourceFile?.path}")
                         sourceFile?.delete()
                     }
-                    finishSuccessfully(null)
+                    result.success(null)
                 }
                 return true
             }
-            else -> return false
         }
     }
 
     private fun copyFileToCacheDirOnBackground(
             context: Context,
             sourceFileUri: Uri,
-            destinationFileName: String) {
+            destinationFileName: String,
+            result: MethodChannel.Result) {
         val uiScope = CoroutineScope(Dispatchers.Main)
         uiScope.launch {
             try {
-                Log.d(LOG_TAG, "Launch...")
                 Log.d(LOG_TAG, "Copy on background...")
                 val filePath = withContext(Dispatchers.IO) {
                     copyFileToCacheDir(context, sourceFileUri, destinationFileName)
                 }
                 Log.d(LOG_TAG, "...copied on background, result: $filePath")
-                finishSuccessfully(filePath)
-                Log.d(LOG_TAG, "...launch")
+                result.success(filePath)
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "copyFileToCacheDirOnBackground failed", e)
-                finishWithError("file_copy_failed", e.localizedMessage, e.toString())
+                result.error("file_copy_failed", e.localizedMessage, e.toString())
             }
         }
     }
@@ -279,13 +329,13 @@ class FileDialog(
             context: Context,
             sourceFileUri: Uri,
             destinationFileName: String): String {
-        // get destination file on cache dir
-        val destinationFile = File(context.cacheDir.path, destinationFileName).apply {
-            if (exists()) {
-                Log.d(LOG_TAG, "Deleting existing destination file '$path'")
-                delete()
-            }
-        }
+        // copy to a unique subdirectory of the cache dir (keeping the display
+        // file name) so concurrent copies of identically named picked files
+        // can never write to the same destination
+        val destinationFile = File(
+                File(context.cacheDir, "file_dialog-${UUID.randomUUID()}"),
+                destinationFileName)
+        destinationFile.parentFile?.mkdirs()
 
         // copy file to cache dir
         Log.d(LOG_TAG, "Copying '$sourceFileUri' to '${destinationFile.path}'")
@@ -339,7 +389,9 @@ class FileDialog(
 
     private fun saveFileOnBackground(
             sourceFile: File,
-            destinationFileUri: Uri
+            destinationFileUri: Uri,
+            isSourceFileTemp: Boolean,
+            result: MethodChannel.Result
     ) {
         val uiScope = CoroutineScope(Dispatchers.Main)
         uiScope.launch {
@@ -349,13 +401,13 @@ class FileDialog(
                     saveFile(sourceFile, destinationFileUri)
                 }
                 Log.d(LOG_TAG, "...saved file on background, result: $filePath")
-                finishSuccessfully(filePath)
+                result.success(filePath)
             } catch (e: SecurityException) {
                 Log.e(LOG_TAG, "saveFileOnBackground", e)
-                finishWithError("security_exception", e.localizedMessage, e.toString())
+                result.error("security_exception", e.localizedMessage, e.toString())
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "saveFileOnBackground failed", e)
-                finishWithError("save_file_failed", e.localizedMessage, e.toString())
+                result.error("save_file_failed", e.localizedMessage, e.toString())
             } finally {
                 if (isSourceFileTemp) {
                     Log.d(LOG_TAG, "Deleting source file: ${sourceFile.path}")
@@ -381,35 +433,47 @@ class FileDialog(
         return destinationFileUri.path!!
     }
 
-    private fun setPendingResult(result: MethodChannel.Result): Boolean {
+    /**
+     * Claims the pending-dialog slot for a new launch and returns the request
+     * code allocated for it, or null if another dialog is already pending.
+     */
+    private fun setPendingDialog(operation: DialogOperation, result: MethodChannel.Result): Int? {
         synchronized(resultLock) {
-            if (pendingResult != null) {
-                return false
+            if (pendingDialog != null) {
+                return null
             }
-            pendingResult = result
-            return true
+            val requestCode = nextRequestCode()
+            // wrap so the result can never be submitted more than once
+            pendingDialog = PendingDialog(operation, SingleCompletionResult(result), requestCode)
+            return requestCode
         }
     }
 
     private fun finishWithAlreadyActiveError(result: MethodChannel.Result) {
         Log.w(LOG_TAG, "File dialog is already active")
+        result.error("already_active", "File dialog is already active", null)
     }
 
-    private fun finishSuccessfully(filePath: String?) {
-        val result: MethodChannel.Result?
+    private fun takePendingResult(): MethodChannel.Result? {
         synchronized(resultLock) {
-            result = pendingResult
-            pendingResult = null
+            val result = pendingDialog?.result
+            pendingDialog = null
+            return result
         }
-        result?.success(filePath)
+    }
+
+    /**
+     * Completes a pending result as cancelled (success(null)). Called by the
+     * plugin when this FileDialog is discarded while a dialog result is still
+     * pending, so the Dart future resolves instead of hanging forever.
+     */
+    internal fun cancelPendingResult() {
+        val result = takePendingResult() ?: return
+        Log.w(LOG_TAG, "Cancelling pending result")
+        result.success(null)
     }
 
     private fun finishWithError(errorCode: String, errorMessage: String?, errorDetails: String?) {
-        val result: MethodChannel.Result?
-        synchronized(resultLock) {
-            result = pendingResult
-            pendingResult = null
-        }
-        result?.error(errorCode, errorMessage, errorDetails)
+        takePendingResult()?.error(errorCode, errorMessage, errorDetails)
     }
 }

--- a/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
+++ b/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FileDialog.kt
@@ -191,14 +191,18 @@ class FileDialog(
                 return
             }
         } else {
-            // write data to a temporary file; on failure release the
-            // pending-dialog slot so later calls do not get already_active
+            // write data to a temporary file; on failure delete the partial
+            // file and release the pending-dialog slot so later calls do not
+            // get already_active
             isSourceFileTemp = true
+            var tempFile: File? = null
             try {
-                sourceFile = File.createTempFile(fileName!!, "")
-                sourceFile!!.writeBytes(data!!)
+                tempFile = File.createTempFile(fileName!!, "")
+                tempFile.writeBytes(data!!)
+                sourceFile = tempFile
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "saveFile - creating temporary file failed", e)
+                tempFile?.delete()
                 finishWithError("save_file_failed", e.localizedMessage, e.toString())
                 return
             }
@@ -235,6 +239,7 @@ class FileDialog(
         // can never block or complete a later dialog's result; consume it only
         // when the request code matches the pending launch, so a re-delivered
         // result from an earlier launch can never complete a newer dialog's
+        // pending result
         val pending: PendingDialog
         synchronized(resultLock) {
             val current = pendingDialog

--- a/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FlutterFileDialogPlugin.kt
+++ b/android/src/main/kotlin/com/kineapps/flutter_file_dialog/FlutterFileDialogPlugin.kt
@@ -105,8 +105,17 @@ class FlutterFileDialogPlugin : FlutterPlugin, ActivityAware, MethodCallHandler 
     private fun doOnAttachedToActivity(activityBinding: ActivityPluginBinding?) {
         Log.d(LOG_TAG, "doOnAttachedToActivity - IN")
 
+        // remove a previously registered FileDialog from the old binding so
+        // stale listeners cannot process dialog results, and resolve its
+        // pending result (if any) so the Dart future does not hang
+        if (fileDialog != null) {
+            this.activityBinding?.removeActivityResultListener(fileDialog!!)
+            fileDialog!!.cancelPendingResult()
+            fileDialog = null
+        }
+
         this.activityBinding = activityBinding
-        activityBinding?.let { createFileDialog(it) } ?: run { this.fileDialog = null }
+        activityBinding?.let { createFileDialog(it) }
 
         Log.d(LOG_TAG, "doOnAttachedToActivity - OUT")
     }
@@ -116,6 +125,7 @@ class FlutterFileDialogPlugin : FlutterPlugin, ActivityAware, MethodCallHandler 
 
         if (fileDialog != null) {
             activityBinding?.removeActivityResultListener(fileDialog!!)
+            fileDialog!!.cancelPendingResult()
             fileDialog = null
         }
         activityBinding = null

--- a/android/src/main/kotlin/com/kineapps/flutter_file_dialog/SingleCompletionResult.kt
+++ b/android/src/main/kotlin/com/kineapps/flutter_file_dialog/SingleCompletionResult.kt
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 KineApps. All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.kineapps.flutter_file_dialog
+
+import android.util.Log
+import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val LOG_TAG = "SingleCompletionResult"
+
+/**
+ * A [MethodChannel.Result] wrapper that guarantees the wrapped result is
+ * completed at most once. Subsequent completion attempts are logged and
+ * ignored instead of throwing IllegalStateException "Reply already submitted".
+ */
+internal class SingleCompletionResult(
+        private val inner: MethodChannel.Result
+) : MethodChannel.Result {
+
+    private val submitted = AtomicBoolean(false)
+
+    override fun success(result: Any?) {
+        if (!submitted.compareAndSet(false, true)) {
+            Log.w(LOG_TAG, "Result already submitted, ignoring success()")
+            return
+        }
+        inner.success(result)
+    }
+
+    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+        if (!submitted.compareAndSet(false, true)) {
+            Log.w(LOG_TAG, "Result already submitted, ignoring error($errorCode)")
+            return
+        }
+        inner.error(errorCode, errorMessage, errorDetails)
+    }
+
+    override fun notImplemented() {
+        if (!submitted.compareAndSet(false, true)) {
+            Log.w(LOG_TAG, "Result already submitted, ignoring notImplemented()")
+            return
+        }
+        inner.notImplemented()
+    }
+}

--- a/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FakeMethodChannelResult.kt
+++ b/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FakeMethodChannelResult.kt
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 KineApps. All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.kineapps.flutter_file_dialog
+
+import io.flutter.plugin.common.MethodChannel
+
+/** Test double recording [MethodChannel.Result] completions. */
+internal class FakeMethodChannelResult : MethodChannel.Result {
+    var successCount = 0
+    var errorCount = 0
+    var notImplementedCount = 0
+    var lastSuccessValue: Any? = null
+    var lastErrorCode: String? = null
+    var lastErrorMessage: String? = null
+    var lastErrorDetails: Any? = null
+
+    val completionCount get() = successCount + errorCount + notImplementedCount
+
+    override fun success(result: Any?) {
+        successCount++
+        lastSuccessValue = result
+    }
+
+    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+        errorCount++
+        lastErrorCode = errorCode
+        lastErrorMessage = errorMessage
+        lastErrorDetails = errorDetails
+    }
+
+    override fun notImplemented() {
+        notImplementedCount++
+    }
+}

--- a/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FileDialogTest.kt
+++ b/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FileDialogTest.kt
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 KineApps. All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.kineapps.flutter_file_dialog
+
+import android.app.Activity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.io.File
+
+class FileDialogTest {
+
+    private fun newDialog(): FileDialog = FileDialog(mock(Activity::class.java))
+
+    private fun newSourceFile(): File =
+            File.createTempFile("file_dialog_test", ".txt").apply {
+                writeText("data")
+                deleteOnExit()
+            }
+
+    private fun startSaveFile(dialog: FileDialog): FakeMethodChannelResult {
+        val result = FakeMethodChannelResult()
+        dialog.saveFile(
+                result = result,
+                sourceFilePath = newSourceFile().path,
+                data = null,
+                fileName = "file.txt",
+                mimeTypesFilter = null,
+                localOnly = false)
+        return result
+    }
+
+    @Test
+    fun `saveFile - should reply already_active when a dialog is already pending`() {
+        // GIVEN
+        val dialog = newDialog()
+        val first = startSaveFile(dialog)
+
+        // WHEN
+        val second = startSaveFile(dialog)
+
+        // THEN
+        assertEquals(0, first.completionCount)
+        assertEquals(1, second.errorCount)
+        assertEquals("already_active", second.lastErrorCode)
+    }
+
+    @Test
+    fun `onActivityResult - should complete cancelled dialog result exactly once`() {
+        // GIVEN
+        val dialog = newDialog()
+        val result = startSaveFile(dialog)
+        val requestCode = dialog.pendingRequestCode
+
+        // WHEN
+        val handled = dialog.onActivityResult(requestCode, Activity.RESULT_CANCELED, null)
+
+        // THEN
+        assertTrue(handled)
+        assertEquals(1, result.successCount)
+        assertNull(result.lastSuccessValue)
+    }
+
+    @Test
+    fun `onActivityResult - should ignore re-delivery after the result is completed`() {
+        // GIVEN
+        val dialog = newDialog()
+        val result = startSaveFile(dialog)
+        val requestCode = dialog.pendingRequestCode
+        dialog.onActivityResult(requestCode, Activity.RESULT_CANCELED, null)
+
+        // WHEN
+        val handled = dialog.onActivityResult(requestCode, Activity.RESULT_CANCELED, null)
+
+        // THEN
+        assertFalse(handled)
+        assertEquals(1, result.completionCount)
+    }
+
+    @Test
+    fun `onActivityResult - should not let a re-delivered old result complete a new dialog`() {
+        // GIVEN a completed first dialog and a second dialog pending
+        val dialog = newDialog()
+        startSaveFile(dialog)
+        val firstRequestCode = dialog.pendingRequestCode
+        dialog.onActivityResult(firstRequestCode, Activity.RESULT_CANCELED, null)
+        val second = startSaveFile(dialog)
+
+        // WHEN the first launch's result is delivered again
+        val handled = dialog.onActivityResult(firstRequestCode, Activity.RESULT_CANCELED, null)
+
+        // THEN it is ignored and the new dialog's result stays pending
+        assertFalse(handled)
+        assertEquals(0, second.completionCount)
+    }
+
+    @Test
+    fun `onActivityResult - should ignore a request code from another FileDialog instance`() {
+        // GIVEN
+        val staleDialog = newDialog()
+        startSaveFile(staleDialog)
+        val staleRequestCode = staleDialog.pendingRequestCode
+        val dialog = newDialog()
+        val result = startSaveFile(dialog)
+
+        // WHEN
+        val handled = dialog.onActivityResult(staleRequestCode, Activity.RESULT_CANCELED, null)
+
+        // THEN
+        assertFalse(handled)
+        assertEquals(0, result.completionCount)
+    }
+
+    @Test
+    fun `onActivityResult - should return false for an unknown request code`() {
+        // GIVEN
+        val dialog = newDialog()
+
+        // WHEN
+        val handled = dialog.onActivityResult(12345, Activity.RESULT_OK, null)
+
+        // THEN
+        assertFalse(handled)
+    }
+
+    @Test
+    fun `cancelPendingResult - should complete pending result as cancelled`() {
+        // GIVEN
+        val dialog = newDialog()
+        val result = startSaveFile(dialog)
+
+        // WHEN
+        dialog.cancelPendingResult()
+
+        // THEN
+        assertEquals(1, result.successCount)
+        assertNull(result.lastSuccessValue)
+    }
+
+    @Test
+    fun `cancelPendingResult - should release the active slot for a new dialog`() {
+        // GIVEN
+        val dialog = newDialog()
+        startSaveFile(dialog)
+        dialog.cancelPendingResult()
+
+        // WHEN
+        val second = startSaveFile(dialog)
+
+        // THEN no already_active error; the new dialog owns the pending slot
+        assertEquals(0, second.completionCount)
+    }
+
+    @Test
+    fun `cancelPendingResult - should do nothing when no result is pending`() {
+        // GIVEN
+        val dialog = newDialog()
+
+        // WHEN / THEN (no exception, nothing to complete)
+        dialog.cancelPendingResult()
+    }
+
+    @Test
+    fun `saveFile - should reply file_not_found for a missing source file`() {
+        // GIVEN
+        val dialog = newDialog()
+        val result = FakeMethodChannelResult()
+
+        // WHEN
+        dialog.saveFile(
+                result = result,
+                sourceFilePath = "/no/such/file.txt",
+                data = null,
+                fileName = "file.txt",
+                mimeTypesFilter = null,
+                localOnly = false)
+
+        // THEN the incoming call's own result is completed and the slot is free
+        assertEquals(1, result.errorCount)
+        assertEquals("file_not_found", result.lastErrorCode)
+        assertEquals(0, startSaveFile(dialog).completionCount)
+    }
+
+    @Test
+    fun `saveFile - should reply internal_error when no activity is available`() {
+        // GIVEN
+        val dialog = FileDialog(null)
+        val result = FakeMethodChannelResult()
+
+        // WHEN
+        dialog.saveFile(
+                result = result,
+                sourceFilePath = newSourceFile().path,
+                data = null,
+                fileName = "file.txt",
+                mimeTypesFilter = null,
+                localOnly = false)
+
+        // THEN
+        assertEquals(1, result.errorCount)
+        assertEquals("internal_error", result.lastErrorCode)
+    }
+}

--- a/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FileDialogTest.kt
+++ b/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FileDialogTest.kt
@@ -213,6 +213,48 @@ class FileDialogTest {
     }
 
     @Test
+    fun `saveFile - should reply invalid_arguments when fileName and data are missing`() {
+        // GIVEN
+        val dialog = newDialog()
+        val result = FakeMethodChannelResult()
+
+        // WHEN
+        dialog.saveFile(
+                result = result,
+                sourceFilePath = null,
+                data = null,
+                fileName = null,
+                mimeTypesFilter = null,
+                localOnly = false)
+
+        // THEN the call fails and the pending-dialog slot stays free
+        assertEquals(1, result.errorCount)
+        assertEquals("invalid_arguments", result.lastErrorCode)
+        assertEquals(0, startSaveFile(dialog).completionCount)
+    }
+
+    @Test
+    fun `saveFile - should release the pending slot when temp file creation fails`() {
+        // GIVEN a fileName too short for File.createTempFile (throws)
+        val dialog = newDialog()
+        val result = FakeMethodChannelResult()
+
+        // WHEN
+        dialog.saveFile(
+                result = result,
+                sourceFilePath = null,
+                data = byteArrayOf(1),
+                fileName = "ab",
+                mimeTypesFilter = null,
+                localOnly = false)
+
+        // THEN the call fails and a new dialog can be started (no already_active)
+        assertEquals(1, result.errorCount)
+        assertEquals("save_file_failed", result.lastErrorCode)
+        assertEquals(0, startSaveFile(dialog).completionCount)
+    }
+
+    @Test
     fun `saveFile - should reply internal_error when no activity is available`() {
         // GIVEN
         val dialog = FileDialog(null)

--- a/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FileDialogTest.kt
+++ b/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FileDialogTest.kt
@@ -158,6 +158,31 @@ class FileDialogTest {
     }
 
     @Test
+    fun `cancelPendingResult - should delete the temporary source file of a pending save`() {
+        // GIVEN a pending saveFile that wrote its data to a temporary file
+        val dialog = newDialog()
+        val result = FakeMethodChannelResult()
+        val fileNamePrefix = "cancel_temp_test_${System.nanoTime()}"
+        dialog.saveFile(
+                result = result,
+                sourceFilePath = null,
+                data = byteArrayOf(1, 2, 3),
+                fileName = fileNamePrefix,
+                mimeTypesFilter = null,
+                localOnly = false)
+
+        // WHEN
+        dialog.cancelPendingResult()
+
+        // THEN the result is cancelled and the temporary file is deleted
+        assertEquals(1, result.successCount)
+        assertNull(result.lastSuccessValue)
+        val leftovers = File(System.getProperty("java.io.tmpdir"))
+                .listFiles { file -> file.name.startsWith(fileNamePrefix) }
+        assertEquals(0, leftovers?.size ?: 0)
+    }
+
+    @Test
     fun `cancelPendingResult - should do nothing when no result is pending`() {
         // GIVEN
         val dialog = newDialog()

--- a/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FlutterFileDialogPluginTest.kt
+++ b/android/src/test/kotlin/com/kineapps/flutter_file_dialog/FlutterFileDialogPluginTest.kt
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 KineApps. All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.kineapps.flutter_file_dialog
+
+import android.app.Activity
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.PluginRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.io.File
+
+class FlutterFileDialogPluginTest {
+
+    private fun newBinding(): ActivityPluginBinding {
+        val binding = mock(ActivityPluginBinding::class.java)
+        `when`(binding.activity).thenReturn(mock(Activity::class.java))
+        return binding
+    }
+
+    private fun attachedFileDialog(plugin: FlutterFileDialogPlugin, binding: ActivityPluginBinding): FileDialog {
+        plugin.onAttachedToActivity(binding)
+        val captor = ArgumentCaptor.forClass(PluginRegistry.ActivityResultListener::class.java)
+        verify(binding).addActivityResultListener(captor.capture())
+        return captor.value as FileDialog
+    }
+
+    private fun startSaveFile(fileDialog: FileDialog): FakeMethodChannelResult {
+        val sourceFile = File.createTempFile("plugin_test", ".txt").apply {
+            writeText("data")
+            deleteOnExit()
+        }
+        val result = FakeMethodChannelResult()
+        fileDialog.saveFile(
+                result = result,
+                sourceFilePath = sourceFile.path,
+                data = null,
+                fileName = "file.txt",
+                mimeTypesFilter = null,
+                localOnly = false)
+        return result
+    }
+
+    @Test
+    fun `onAttachedToActivity - should unregister previous FileDialog and cancel its pending result`() {
+        // GIVEN a plugin attached to an activity with a dialog result pending
+        val plugin = FlutterFileDialogPlugin()
+        val firstBinding = newBinding()
+        val firstFileDialog = attachedFileDialog(plugin, firstBinding)
+        val pending = startSaveFile(firstFileDialog)
+
+        // WHEN the plugin is attached again without a detach in between
+        val secondBinding = newBinding()
+        plugin.onAttachedToActivity(secondBinding)
+
+        // THEN the stale listener is removed from the old binding, its pending
+        // result resolves as cancelled, and a new listener is registered
+        verify(firstBinding).removeActivityResultListener(firstFileDialog)
+        assertEquals(1, pending.successCount)
+        assertNull(pending.lastSuccessValue)
+        verify(secondBinding).addActivityResultListener(any())
+    }
+
+    @Test
+    fun `onDetachedFromActivity - should unregister FileDialog and cancel its pending result`() {
+        // GIVEN a plugin attached to an activity with a dialog result pending
+        val plugin = FlutterFileDialogPlugin()
+        val binding = newBinding()
+        val fileDialog = attachedFileDialog(plugin, binding)
+        val pending = startSaveFile(fileDialog)
+
+        // WHEN
+        plugin.onDetachedFromActivity()
+
+        // THEN
+        verify(binding).removeActivityResultListener(fileDialog)
+        assertEquals(1, pending.successCount)
+        assertNull(pending.lastSuccessValue)
+    }
+}

--- a/android/src/test/kotlin/com/kineapps/flutter_file_dialog/SingleCompletionResultTest.kt
+++ b/android/src/test/kotlin/com/kineapps/flutter_file_dialog/SingleCompletionResultTest.kt
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 KineApps. All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.kineapps.flutter_file_dialog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SingleCompletionResultTest {
+
+    @Test
+    fun `success - should delegate exactly once with the right value`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+
+        // WHEN
+        result.success("file/path")
+
+        // THEN
+        assertEquals(1, fake.successCount)
+        assertEquals("file/path", fake.lastSuccessValue)
+    }
+
+    @Test
+    fun `success - should ignore a second success`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+        result.success("first")
+
+        // WHEN
+        result.success("second")
+
+        // THEN
+        assertEquals(1, fake.successCount)
+        assertEquals("first", fake.lastSuccessValue)
+    }
+
+    @Test
+    fun `success - should be ignored after error`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+        result.error("some_error", "message", null)
+
+        // WHEN
+        result.success("value")
+
+        // THEN
+        assertEquals(1, fake.errorCount)
+        assertEquals(0, fake.successCount)
+    }
+
+    @Test
+    fun `error - should delegate exactly once with the right arguments`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+
+        // WHEN
+        result.error("some_error", "message", "details")
+
+        // THEN
+        assertEquals(1, fake.errorCount)
+        assertEquals("some_error", fake.lastErrorCode)
+        assertEquals("message", fake.lastErrorMessage)
+        assertEquals("details", fake.lastErrorDetails)
+    }
+
+    @Test
+    fun `error - should be ignored after success`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+        result.success(null)
+
+        // WHEN
+        result.error("some_error", "message", null)
+
+        // THEN
+        assertEquals(1, fake.successCount)
+        assertNull(fake.lastSuccessValue)
+        assertEquals(0, fake.errorCount)
+    }
+
+    @Test
+    fun `notImplemented - should delegate on first call`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+
+        // WHEN
+        result.notImplemented()
+
+        // THEN
+        assertEquals(1, fake.notImplementedCount)
+    }
+
+    @Test
+    fun `notImplemented - should be ignored after success`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+        result.success("value")
+
+        // WHEN
+        result.notImplemented()
+
+        // THEN
+        assertEquals(1, fake.successCount)
+        assertEquals(0, fake.notImplementedCount)
+    }
+
+    @Test
+    fun `notImplemented - should suppress subsequent success and error`() {
+        // GIVEN
+        val fake = FakeMethodChannelResult()
+        val result = SingleCompletionResult(fake)
+        result.notImplemented()
+
+        // WHEN
+        result.success("value")
+        result.error("some_error", null, null)
+
+        // THEN
+        assertEquals(1, fake.notImplementedCount)
+        assertEquals(0, fake.successCount)
+        assertEquals(0, fake.errorCount)
+    }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_file_dialog
 description: Dialogs for picking and saving files in Android and in iOS.
-version: 3.3.1
+version: 3.3.2
 homepage: https://github.com/kineapps/flutter_file_dialog
 repository: https://github.com/kineapps/flutter_file_dialog
 


### PR DESCRIPTION
## Summary
- Fix the fatal Android crash `IllegalStateException: Reply already submitted` in `FileDialog` by guaranteeing every dialog result is completed exactly once: pending results are wrapped in a new once-only `SingleCompletionResult`, request codes are allocated per dialog launch and matched exactly on `onActivityResult`, and stale activity-result listeners are unregistered (with their pending result cancelled) on plugin re-attach/detach
- Invoking `pickFile`/`saveFile`/`pickDirectory` while a dialog is already open now replies with an `already_active` error instead of leaving the call unanswered forever
- A slow post-dialog cache copy (e.g. from a flaky cloud document provider) no longer blocks subsequent dialogs, and picked files are copied into unique cache subdirectories so concurrent copies of identically named files cannot collide

## Test plan
- New JVM unit tests (JUnit + Mockito): 21 tests covering the once-only completion guard, dialog result ownership (already-active, re-delivery, stale request codes, cancellation), and plugin lifecycle cleanup — `./gradlew :flutter_file_dialog:testDebugUnitTest`
- `flutter analyze` clean; example app builds (`flutter build apk --debug`)
- Manually verified on a physical Android device: pick/cancel/reopen cycles, file pick with cache copy, rotation while the dialog is open, and recovery after a hung OneDrive provider copy

fixes #58